### PR TITLE
feat: Implement PostgresLoader and enhance SPL parser

### DIFF
--- a/src/py_load_spl/db/postgres.py
+++ b/src/py_load_spl/db/postgres.py
@@ -68,9 +68,44 @@ class PostgresLoader(DatabaseLoader):
             raise
 
     def bulk_load_to_staging(self, intermediate_dir: Path) -> None:
-        logger.info(f"Bulk loading data from {intermediate_dir} to staging tables...")
-        # TODO: Use psycopg2's `copy_expert` to run the COPY command for each CSV.
-        logger.info("Bulk load to staging complete.")
+        """Loads data from CSV files into staging tables using COPY."""
+        logger.info(f"Bulk loading data from {intermediate_dir} into staging tables...")
+        # Map CSV filenames to their target staging tables
+        file_to_table_map = {
+            "products.csv": "products_staging",
+            "ingredients.csv": "ingredients_staging",
+            "packaging.csv": "packaging_staging",
+            "marketing_status.csv": "marketing_status_staging",
+            "product_ndcs.csv": "product_ndcs_staging",
+            "spl_raw_documents.csv": "spl_raw_documents_staging",
+        }
+
+        try:
+            with self._get_conn() as conn:
+                with conn.cursor() as cur:
+                    for filename, table_name in file_to_table_map.items():
+                        filepath = intermediate_dir / filename
+                        if not filepath.exists():
+                            logger.warning(
+                                f"Intermediate file {filepath} not found. Skipping."
+                            )
+                            continue
+
+                        logger.info(f"Loading {filename} into {table_name}...")
+                        # F007.1: Use copy_expert for efficient bulk loading
+                        sql = f"""
+                            COPY {table_name} FROM STDIN
+                            WITH (FORMAT CSV, NULL '\\N', QUOTE '\"');
+                        """
+                        with open(filepath, "r", encoding="utf-8") as f:
+                            cur.copy_expert(sql, f)
+                conn.commit()
+            logger.info("Bulk load to staging tables complete.")
+        except (psycopg2.Error, IOError) as e:
+            logger.error(f"Bulk load to staging failed: {e}")
+            if self.conn:
+                self.conn.rollback()
+            raise
 
     def pre_load_optimization(self) -> None:
         logger.info(
@@ -80,12 +115,48 @@ class PostgresLoader(DatabaseLoader):
         logger.info("Pre-load optimizations complete.")
 
     def merge_from_staging(self, mode: Literal["full-load", "delta-load"]) -> None:
-        logger.info(f"Merging data from staging to production tables (mode: {mode})...")
-        # TODO:
-        # If 'full-load': TRUNCATE production tables and INSERT from staging.
-        # If 'delta-load': Use INSERT ... ON CONFLICT (UPSERT) logic.
-        # This must be done in a single transaction (F006.3).
-        logger.info("Merge complete.")
+        """
+        Merges data from staging to production tables.
+        For this implementation, we only support 'full-load'.
+        """
+        logger.info(f"Merging data from staging to production (mode: {mode})...")
+        if mode != "full-load":
+            logger.warning(f"Merge mode '{mode}' is not yet implemented. Skipping.")
+            return
+
+        # List of tables to truncate and load, in order of dependency
+        tables = [
+            "product_ndcs",
+            "ingredients",
+            "packaging",
+            "marketing_status",
+            "products",
+            "spl_raw_documents",
+        ]
+
+        try:
+            with self._get_conn() as conn:
+                with conn.cursor() as cur:
+                    # F006.3: This block is executed in a single transaction
+                    logger.info("Truncating production tables...")
+                    for table in tables:
+                        cur.execute(f"TRUNCATE TABLE {table} CASCADE;")
+
+                    logger.info("Inserting data from staging tables...")
+                    for table in reversed(tables):  # Insert in reverse order
+                        cur.execute(f"INSERT INTO {table} SELECT * FROM {table}_staging;")
+
+                    logger.info("Truncating staging tables after merge...")
+                    for table in tables:
+                        cur.execute(f"TRUNCATE TABLE {table}_staging;")
+
+                conn.commit()
+            logger.info("Merge from staging to production complete.")
+        except psycopg2.Error as e:
+            logger.error(f"Merge from staging failed: {e}")
+            if self.conn:
+                self.conn.rollback()
+            raise
 
     def post_load_cleanup(self) -> None:
         logger.info("Performing post-load cleanup (rebuilding indexes, analyzing)...")

--- a/src/py_load_spl/parsing.py
+++ b/src/py_load_spl/parsing.py
@@ -62,9 +62,13 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
         product_element = _xp(root, ".//hl7:manufacturedProduct/hl7:manufacturedProduct")
         if product_element is not None:
             data["product_name"] = _xp(product_element, ".//hl7:name").text
-            data["dosage_form"] = _xp(product_element, ".//hl7:formCode").get("displayName")
-            # Route of administration is often in a similar place, but not in the sample
-            # data["route_of_administration"] = ...
+            data["dosage_form"] = _xp(product_element, ".//hl7:formCode").get(
+                "displayName"
+            )
+            # F002.3: Extract route of administration (best guess)
+            route_code_el = _xp(product_element, ".//hl7:routeCode")
+            if route_code_el is not None:
+                data["route_of_administration"] = route_code_el.get("displayName")
 
         manufacturer = _xp(root, ".//hl7:manufacturer/hl7:name")
         if manufacturer is not None:

--- a/tests/test_full_pipeline.py
+++ b/tests/test_full_pipeline.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import tempfile
+from pathlib import Path
+import os
+
+from py_load_spl.config import DatabaseSettings
+from py_load_spl.db.postgres import PostgresLoader
+from py_load_spl.parsing import iter_spl_files
+from py_load_spl.transformation import Transformer
+
+SAMPLE_XML_WITH_ROUTE = """<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="urn:hl7-org:v3">
+  <id root="d1b64b62-050a-4895-924c-d2862d2a6a69" />
+  <setId root="a2c3b6f0-a38f-4b48-96eb-3b2b403816a4" />
+  <versionNumber value="1" />
+  <effectiveTime value="20250907" />
+  <subject>
+    <manufacturedProduct>
+      <manufacturedProduct>
+        <name>Jules's Sample Drug</name>
+        <formCode code="C42916" displayName="TABLET" />
+        <routeCode code="C38288" displayName="ORAL" />
+        <asEntityWithGeneric>
+          <genericMedicine>
+            <name>JULAMYCIN</name>
+          </genericMedicine>
+        </asEntityWithGeneric>
+      </manufacturedProduct>
+    </manufacturedProduct>
+  </subject>
+</document>
+"""
+
+
+@patch("py_load_spl.db.postgres.psycopg2")
+def test_full_etl_pipeline_mocked(mock_psycopg2):
+    """
+    Tests the full ETL pipeline with a mocked database to avoid docker issues.
+    Verifies that the correct data is generated and that the loader methods
+    are called as expected.
+    """
+    with tempfile.TemporaryDirectory() as source_dir_str, tempfile.TemporaryDirectory() as output_dir_str:
+        source_dir = Path(source_dir_str)
+        output_dir = Path(output_dir_str)
+
+        # 1. Arrange: Create a sample XML file and set up mocks
+        xml_file = source_dir / "sample.xml"
+        xml_file.write_text(SAMPLE_XML_WITH_ROUTE)
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_psycopg2.connect.return_value = mock_conn
+        # Ensure the cursor() context manager returns our mock cursor
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        db_settings = DatabaseSettings(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            name="test",
+            adapter="postgresql",
+        )
+        loader = PostgresLoader(db_settings)
+
+        # 2. Act: Run the E-T-L process
+        parsed_stream = iter_spl_files(source_dir)
+        transformer = Transformer(output_dir)
+        transformer.transform_stream(parsed_stream)
+
+        loader.initialize_schema()
+        loader.bulk_load_to_staging(output_dir)
+        loader.merge_from_staging(mode="full-load")
+
+        # 3. Assert
+        # Assert that the CSV was created correctly with the new field
+        products_csv = output_dir / "products.csv"
+        assert products_csv.exists()
+        with open(products_csv, "r") as f:
+            content = f.read()
+            # The order of columns in the model is: document_id, set_id, version_number,
+            # effective_time, product_name, manufacturer_name, dosage_form, route_of_administration
+            assert 'ORAL' in content
+            assert 'd1b64b62-050a-4895-924c-d2862d2a6a69' in content
+            print("Verified 'ORAL' is present in the output products.csv")
+
+        # Assert that the database methods were called
+        mock_psycopg2.connect.assert_called()
+        mock_conn.cursor.assert_called()
+        # Check that initialize_schema was called
+        assert mock_cur.execute.call_count > 0
+        # Check that bulk_load_to_staging was called (via copy_expert)
+        assert mock_cur.copy_expert.call_count > 0
+        # Check that merge_from_staging was called (via execute)
+        # It should truncate tables and then insert into them
+        truncate_calls = [call for call in mock_cur.execute.call_args_list if "TRUNCATE" in call[0][0]]
+        insert_calls = [call for call in mock_cur.execute.call_args_list if "INSERT INTO" in call[0][0]]
+        assert len(truncate_calls) > 0
+        assert len(insert_calls) > 0
+        print("Verified that database loader methods were called.")


### PR DESCRIPTION
This commit implements key missing features in the py-load-spl package based on the FRD.

Key changes:
- **Implemented `PostgresLoader`**: The `bulk_load_to_staging` and `merge_from_staging` methods in `src/py_load_spl/db/postgres.py` have been implemented. The loader now supports a 'full-load' ETL process, using the efficient `COPY` command to load data into staging tables and then merging it into production tables atomically.
- **Enhanced SPL Parser**: The parser in `src/py_load_spl/parsing.py` has been enhanced to extract the `route_of_administration` from SPL files. This was based on an educated guess of the XML structure (`<routeCode displayName=.../>`) as no definitive example could be found.
- **Added Mocked Integration Test**: A new test file, `tests/test_full_pipeline.py`, has been added. This file contains an end-to-end test that mocks the database connection to verify the full ETL pipeline, from parsing to transformation to loading, including the newly added `route_of_administration` field.

Known Issues:
- Several existing integration tests are failing due to issues in the testing environment:
  - Tests relying on `testcontainers` (e.g., in `test_postgres_loader.py`, `test_cli.py`) fail due to a Docker permission error (`PermissionError: [Errno 13] Permission denied`).
  - `test_acquisition.py` fails due to an outdated HTML fixture. These issues are pre-existing and were not addressed as part of this change, but are noted here for future work.