### PR TITLE
This commit refactors the `delta_load` command and the `acquisition` …

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "postgresql"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:3af992a9b3d3a6aa71b2062520e67d2771b498d143a6a34caaecf125fa9c04cc"
+content_hash = "sha256:612b88b8f1f068c35bd06de3de492126832caaa3369a3b65557ae01eff3af3b0"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -718,7 +718,7 @@ name = "psycopg2-binary"
 version = "2.9.10"
 requires_python = ">=3.8"
 summary = "psycopg2 - Python-PostgreSQL Database Adapter"
-groups = ["postgresql"]
+groups = ["dev", "postgresql"]
 files = [
     {file = "psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2"},
     {file = "psycopg2_binary-2.9.10-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:0ea8e3d0ae83564f2fc554955d327fa081d065c8ca5cc6d2abb643e2c9c1200f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-cov",
     "testcontainers",
+    "psycopg2-binary",
     "ruff>=0.12.12",
     "black>=25.1.0",
     "mypy>=1.17.1",

--- a/src/py_load_spl/acquisition.py
+++ b/src/py_load_spl/acquisition.py
@@ -15,8 +15,8 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from py_load_spl.config import Settings, get_settings
-from py_load_spl.db.postgres import PostgresLoader
+from .config import Settings, get_settings
+from .db.base import DatabaseLoader
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
         raise
 
 
-def download_spl_archives() -> List[Archive]:
+def download_spl_archives(loader: DatabaseLoader) -> List[Archive]:
     """
     Main function for F001: Data Acquisition.
 
@@ -132,15 +132,15 @@ def download_spl_archives() -> List[Archive]:
     available archives, compares it against previously processed archives
     stored in the database, and downloads only the new ones.
 
+    Args:
+        loader: An initialized database loader instance.
+
     Returns:
         A list of Archive objects that were newly downloaded.
     """
     logger.info("Starting stateful SPL data acquisition...")
     settings = get_settings()
 
-    # Instantiate loader to get state from the database.
-    # In a larger application, this might be handled by dependency injection.
-    loader = PostgresLoader(settings.db)
     try:
         processed_archives_names = loader.get_processed_archives()
     except Exception as e:

--- a/src/py_load_spl/cli.py
+++ b/src/py_load_spl/cli.py
@@ -8,8 +8,10 @@ import typer
 from rich.console import Console
 
 from . import __name__ as app_name
-from .acquisition import Archive
+from .acquisition import Archive, download_spl_archives
 from .config import get_settings
+from .db.base import DatabaseLoader
+from .db.postgres import PostgresLoader
 from .parsing import iter_spl_files
 from .transformation import Transformer
 
@@ -41,20 +43,27 @@ def main(
         console.print("[bold red]No command specified. Use --help for options.[/bold red]")
 
 
-from .acquisition import download_spl_archives
-
-
 @app.command()
 def download(ctx: typer.Context) -> None:
     """
     F001: Download SPL archives from the FDA source.
     This command fetches the list of available SPL data archives and
-    downloads a sample file to demonstrate the functionality.
+    downloads only new archives based on the database state.
     """
+    settings = ctx.obj
+    # This is a simple factory, could be expanded for other adapters
+    if settings.db.adapter == "postgresql":
+        loader: DatabaseLoader = PostgresLoader(settings.db)
+    else:
+        console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
+        raise typer.Exit(1)
+
     console.print("[bold green]Starting data acquisition process...[/bold green]")
     try:
-        download_spl_archives()
-        console.print("[bold green]Data acquisition command finished.[/bold green]")
+        newly_downloaded = download_spl_archives(loader)
+        console.print(
+            f"[bold green]Data acquisition command finished. Downloaded {len(newly_downloaded)} new archives.[/bold green]"
+        )
     except Exception as e:
         console.print(f"[bold red]An error occurred during data acquisition: {e}[/bold red]")
         raise typer.Exit(1)
@@ -65,13 +74,11 @@ def init(ctx: typer.Context) -> None:
     """
     F008.3: Initialize the database schema.
     """
-    from .db.postgres import PostgresLoader
-
     console.print("[bold green]Initializing database schema...[/bold green]")
     settings = ctx.obj
     # This is a simple factory, could be expanded for other adapters
     if settings.db.adapter == "postgresql":
-        loader = PostgresLoader(settings.db)
+        loader: DatabaseLoader = PostgresLoader(settings.db)
     else:
         console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
         raise typer.Exit(1)
@@ -82,9 +89,6 @@ def init(ctx: typer.Context) -> None:
     except Exception as e:
         console.print(f"[bold red]Schema initialization failed: {e}[/bold red]")
         raise typer.Exit(1)
-
-
-from .db.postgres import PostgresLoader
 
 
 @app.command()
@@ -111,7 +115,7 @@ def full_load(
 
     # Initialize the correct database loader
     if settings.db.adapter == "postgresql":
-        loader = PostgresLoader(settings.db)
+        loader: DatabaseLoader = PostgresLoader(settings.db)
     else:
         console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
         raise typer.Exit(1)
@@ -165,16 +169,22 @@ def delta_load(ctx: typer.Context) -> None:
     settings = ctx.obj
     console.print("[bold blue]Starting delta data load...[/bold blue]")
     run_id = None
+    loader: DatabaseLoader | None = None  # Initialize loader to None
     try:
+        # Initialize the correct database loader
+        if settings.db.adapter == "postgresql":
+            loader = PostgresLoader(settings.db)
+        else:
+            console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
+            raise typer.Exit(1)
+
         # 1. Acquisition: Find and download new archives
         console.print("[cyan]Step 1: Acquiring new archives...[/cyan]")
-        newly_downloaded_archives: List[Archive] = download_spl_archives()
+        newly_downloaded_archives: List[Archive] = download_spl_archives(loader)
         if not newly_downloaded_archives:
             console.print("[green]No new archives to process. Database is up to date.[/green]")
             return
 
-        # Initialize the loader once
-        loader = PostgresLoader(settings.db)
         run_id = loader.start_run(mode="delta-load")
         total_archives_processed = 0
 
@@ -213,14 +223,14 @@ def delta_load(ctx: typer.Context) -> None:
                 # Continue to the next archive
                 continue
 
-        loader.end_run(run_id, "SUCCESS", archives_processed=total_archives_processed)
+        if run_id:
+            loader.end_run(run_id, "SUCCESS", archives_processed=total_archives_processed)
         console.print("[bold green]Delta load process finished successfully.[/bold green]")
 
     except Exception as e:
         console.print(f"[bold red]An error occurred during the delta load process: {e}[/bold red]")
-        if run_id:
-            # This assumes loader was initialized
-            PostgresLoader(settings.db).end_run(run_id, "FAILED", error_log=str(e))
+        if loader and run_id:
+            loader.end_run(run_id, "FAILED", error_log=str(e))
         raise typer.Exit(1)
 
 

--- a/src/py_load_spl/parsing.py
+++ b/src/py_load_spl/parsing.py
@@ -162,22 +162,23 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
                             }
                         )
 
-                # New, more robust marketing status extraction
-                marketing_acts = _xpa(packaging_section, "./hl7:subject/hl7:marketingAct")
-                for act in marketing_acts:
-                    status_code_el = _xp(act, "./hl7:statusCode")
-                    effective_time_el = _xp(act, "./hl7:effectiveTime")
+            # New, more robust marketing status extraction
+            # Search for all marketing acts anywhere in the structured body
+            marketing_acts = _xpa(body, ".//hl7:subject/hl7:marketingAct")
+            for act in marketing_acts:
+                status_code_el = _xp(act, "./hl7:statusCode")
+                effective_time_el = _xp(act, "./hl7:effectiveTime")
 
-                    start_date_el = _xp(effective_time_el, "./hl7:low") if effective_time_el is not None else None
-                    end_date_el = _xp(effective_time_el, "./hl7:high") if effective_time_el is not None else None
+                start_date_el = _xp(effective_time_el, "./hl7:low") if effective_time_el is not None else None
+                end_date_el = _xp(effective_time_el, "./hl7:high") if effective_time_el is not None else None
 
-                    data["marketing_status"].append(
-                        {
-                            "marketing_category": status_code_el.get("code") if status_code_el is not None else None,
-                            "start_date": start_date_el.get("value") if start_date_el is not None else None,
-                            "end_date": end_date_el.get("value") if end_date_el is not None else None,
-                        }
-                    )
+                data["marketing_status"].append(
+                    {
+                        "marketing_category": status_code_el.get("code") if status_code_el is not None else None,
+                        "start_date": start_date_el.get("value") if start_date_el is not None else None,
+                        "end_date": end_date_el.get("value") if end_date_el is not None else None,
+                    }
+                )
 
     except (AttributeError, TypeError, ValueError) as e:
         # F002.4: Gracefully handle parsing errors

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ def mock_db_loader(monkeypatch: pytest.MonkeyPatch):
             # Return an empty set to simulate no archives being processed yet
             return set()
 
-    monkeypatch.setattr("py_load_spl.acquisition.PostgresLoader", MockLoader)
+    monkeypatch.setattr("py_load_spl.cli.PostgresLoader", MockLoader)
 
 
 def test_download_command(


### PR DESCRIPTION
…module to correctly use the `DatabaseLoader` abstraction.

Previously, both the `delta_load` command in `cli.py` and the `download_spl_archives` function in `acquisition.py` had a hardcoded dependency on `PostgresLoader`. This violated the adapter pattern, which is a core architectural principle of this application, and made it impossible to use the delta loading functionality with any other database.

This change introduces the following fixes:
- The `download_spl_archives` function now accepts a `DatabaseLoader` instance via dependency injection.
- The `delta_load` and `download` CLI commands now use a factory pattern to create the correct database loader based on configuration and pass it to the acquisition module.
- The test suite has been updated to reflect these changes, including fixing monkeypatch targets.

Additionally, this commit includes fixes for the test suite and a bug in the parsing logic that were discovered during testing:
- Adds `psycopg2-binary` to the dev dependencies in `pyproject.toml` to ensure tests can run correctly.
- Adds a missing test data file required by `test_marketing_status_parsing.py`.
- Fixes a bug in `parsing.py` where only the first of multiple marketing status sections was being processed. The logic now correctly finds all marketing status sections within a document.