### PR TITLE
feat: Implement and test the delta-load command

### DIFF
--- a/src/py_load_spl/acquisition.py
+++ b/src/py_load_spl/acquisition.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import re
 from pathlib import Path
-from typing import List, TypedDict
+from typing import List
 
 import requests
 from bs4 import BeautifulSoup
@@ -17,16 +17,9 @@ from rich.progress import (
 
 from .config import Settings, get_settings
 from .db.base import DatabaseLoader
+from .models import Archive
 
 logger = logging.getLogger(__name__)
-
-
-class Archive(TypedDict):
-    """Represents a downloadable SPL archive file."""
-
-    name: str
-    url: str
-    checksum: str
 
 
 def get_archive_list(settings: Settings) -> List[Archive]:
@@ -59,11 +52,11 @@ def get_archive_list(settings: Settings) -> List[Archive]:
         checksum_match = re.search(r"MD5 checksum:\s*([0-9a-fA-F]{32})", li.get_text())
         if checksum_match:
             archives.append(
-                {
-                    "name": href.split("/")[-1],
-                    "url": href,
-                    "checksum": checksum_match.group(1).strip(),
-                }
+                Archive(
+                    name=href.split("/")[-1],
+                    url=href,
+                    checksum=checksum_match.group(1).strip(),
+                )
             )
 
     if not archives:
@@ -79,9 +72,9 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
     """
     download_dir = Path(settings.download_path)
     download_dir.mkdir(parents=True, exist_ok=True)
-    file_path = download_dir / archive["name"]
+    file_path = download_dir / archive.name
 
-    logger.info("Downloading %s to %s", archive["url"], file_path)
+    logger.info("Downloading %s to %s", archive.url, file_path)
 
     progress = Progress(
         TextColumn("[bold blue]{task.fields[filename]}", justify="right"),
@@ -97,10 +90,10 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
 
     md5 = hashlib.md5()
     try:
-        with requests.get(archive["url"], stream=True, timeout=300) as r:
+        with requests.get(archive.url, stream=True, timeout=300) as r:
             r.raise_for_status()
             total_size = int(r.headers.get("content-length", 0))
-            task_id = progress.add_task("download", total=total_size, filename=archive["name"])
+            task_id = progress.add_task("download", total=total_size, filename=archive.name)
             with open(file_path, "wb") as f, progress:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
@@ -108,16 +101,16 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
                     progress.update(task_id, advance=len(chunk))
 
         calculated_checksum = md5.hexdigest()
-        if calculated_checksum.lower() != archive["checksum"].lower():
+        if calculated_checksum.lower() != archive.checksum.lower():
             file_path.unlink()  # Delete corrupted file
             raise ValueError(
-                f"Checksum mismatch for {archive['name']}. "
-                f"Expected {archive['checksum']}, got {calculated_checksum}."
+                f"Checksum mismatch for {archive.name}. "
+                f"Expected {archive.checksum}, got {calculated_checksum}."
             )
-        logger.info("Checksum verified for %s", archive["name"])
+        logger.info("Checksum verified for %s", archive.name)
         return file_path
     except (requests.RequestException, ValueError) as e:
-        logger.error("Failed to download or verify %s: %s", archive["name"], e)
+        logger.error("Failed to download or verify %s: %s", archive.name, e)
         # Clean up partial download if it exists
         if file_path.exists():
             file_path.unlink(missing_ok=True)
@@ -156,7 +149,7 @@ def download_spl_archives(loader: DatabaseLoader) -> List[Archive]:
         return []
 
     # Determine which archives are new
-    all_available_archives_map = {a["name"]: a for a in all_available_archives}
+    all_available_archives_map = {a.name: a for a in all_available_archives}
     new_archive_names = set(all_available_archives_map.keys()) - processed_archives_names
 
     if not new_archive_names:

--- a/src/py_load_spl/cli.py
+++ b/src/py_load_spl/cli.py
@@ -102,10 +102,77 @@ def full_load(
         raise typer.Exit(1)
 
 
+from .acquisition import download_spl_archives
+from .util import unzip_archive
+
+
 @app.command()
 def delta_load(ctx: typer.Context) -> None:
-    """F008.3: Perform an incremental (delta) load. (Not Implemented)"""
-    console.print("[bold yellow]Delta load is not yet implemented.[/bold yellow]")
+    """F008.3: Perform an incremental (delta) load from the FDA source."""
+    settings = ctx.obj
+    console.print("[bold cyan]Starting delta data load from FDA source...[/bold cyan]")
+    loader = get_db_loader(settings)
+    run_id = None
+    downloaded_archives = []
+    try:
+        run_id = loader.start_run(mode="delta-load")
+
+        # Step 1: Download new archives
+        console.print("[cyan]Step 1: Checking for and downloading new archives...[/cyan]")
+        downloaded_archives = download_spl_archives(loader)
+        if not downloaded_archives:
+            console.print("[green]No new archives found. Database is up-to-date.[/green]")
+            loader.end_run(run_id, "SUCCESS", 0)
+            return
+
+        console.print(f"[green]Downloaded {len(downloaded_archives)} new archive(s).[/green]")
+
+        # Create temporary directories for processing
+        with tempfile.TemporaryDirectory() as xml_temp_dir_str, \
+             tempfile.TemporaryDirectory() as csv_temp_dir_str:
+
+            xml_temp_dir = Path(xml_temp_dir_str)
+            csv_temp_dir = Path(csv_temp_dir_str)
+
+            # Step 2: Unzip all archives
+            console.print(f"[cyan]Step 2: Extracting XML files to {xml_temp_dir}...[/cyan]")
+            for archive in downloaded_archives:
+                archive_path = Path(settings.download_path) / archive.name
+                unzip_archive(archive_path, xml_temp_dir)
+
+            # Step 3: Transform XMLs to CSVs
+            console.print(f"[cyan]Step 3: Parsing and Transforming XMLs to CSVs in {csv_temp_dir}...[/cyan]")
+            parsed_data_stream = iter_spl_files(xml_temp_dir)
+            transformer = Transformer(output_dir=csv_temp_dir)
+            stats = transformer.transform_stream(parsed_data_stream)
+            console.print("[green]Parsing and Transformation complete.[/green]")
+
+            # Step 4: Load data into database
+            console.print("[cyan]Step 4: Loading data into database...[/cyan]")
+            loader.pre_load_optimization()
+            loader.bulk_load_to_staging(csv_temp_dir)
+            loader.merge_from_staging("delta-load")
+            loader.post_load_cleanup()
+            console.print("[green]Database loading complete.[/green]")
+
+            # Step 5: Record processed archives
+            console.print("[cyan]Step 5: Recording processed archives in database...[/cyan]")
+            for archive in downloaded_archives:
+                loader.record_processed_archive(archive.name, archive.checksum)
+
+        if run_id:
+            # Use the stats from the transformer for a more accurate count
+            total_records = sum(stats.values()) if stats else 0
+            loader.end_run(run_id, "SUCCESS", total_records)
+        console.print("[bold green]Delta load process finished successfully.[/bold green]")
+
+    except Exception as e:
+        console.print(f"[bold red]An error occurred during the delta load process: {e}[/bold red]")
+        # Also log the traceback for debugging
+        logging.getLogger(__name__).exception("Delta load failed")
+        if run_id:
+            loader.end_run(run_id, "FAILED", 0, str(e))
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/src/py_load_spl/models.py
+++ b/src/py_load_spl/models.py
@@ -28,6 +28,14 @@ class Product(BaseModel):
         return v
 
 
+class Archive(BaseModel):
+    """Data model for a downloadable SPL archive file."""
+
+    name: str
+    url: str
+    checksum: str
+
+
 class ProductNdc(BaseModel):
     """Data model for the 'product_ndcs' table."""
 

--- a/src/py_load_spl/util.py
+++ b/src/py_load_spl/util.py
@@ -32,3 +32,27 @@ def setup_logging(log_level: str, log_format: str):
     logging.getLogger(__name__).info(
         f"Logging configured. Level: {log_level}, Format: {log_format}"
     )
+
+
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def unzip_archive(archive_path: Path, extract_to: Path) -> None:
+    """
+    Extracts a zip archive to a specified directory.
+
+    Args:
+        archive_path: The path to the zip file.
+        extract_to: The directory where contents should be extracted.
+    """
+    logger.info(f"Extracting '{archive_path.name}' to '{extract_to}'...")
+    try:
+        with zipfile.ZipFile(archive_path, "r") as zip_ref:
+            zip_ref.extractall(extract_to)
+        logger.info(f"Successfully extracted '{archive_path.name}'.")
+    except (zipfile.BadZipFile, FileNotFoundError) as e:
+        logger.error(f"Failed to extract archive {archive_path}: {e}")
+        raise

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,8 +1,9 @@
 import pytest
 import requests
 import requests_mock
-from py_load_spl.acquisition import Archive, get_archive_list
+from py_load_spl.acquisition import get_archive_list
 from py_load_spl.config import Settings
+from py_load_spl.models import Archive
 
 # A simplified HTML fixture mimicking the structure of the DailyMed page
 HTML_FIXTURE = """
@@ -62,8 +63,8 @@ def test_get_archive_list_success():
         ),
     ]
 
-    # Sort lists of dicts to ensure comparison is order-independent
-    assert sorted(archives, key=lambda x: x['name']) == sorted(expected_archives, key=lambda x: x['name'])
+    # Sort lists of Pydantic models to ensure comparison is order-independent
+    assert sorted(archives, key=lambda x: x.name) == sorted(expected_archives, key=lambda x: x.name)
 
 
 def test_get_archive_list_http_error():
@@ -110,10 +111,10 @@ def test_download_archive_success(tmp_path: Path):
     settings = Settings(download_path=str(tmp_path))
 
     with requests_mock.Mocker() as m:
-        m.get(archive["url"], content=mock_content, headers={"Content-Length": str(len(mock_content))})
+        m.get(archive.url, content=mock_content, headers={"Content-Length": str(len(mock_content))})
         result_path = download_archive(archive, settings)
 
-    expected_path = tmp_path / archive["name"]
+    expected_path = tmp_path / archive.name
     assert result_path == expected_path
     assert expected_path.exists()
     assert expected_path.read_bytes() == mock_content
@@ -131,10 +132,10 @@ def test_download_archive_checksum_mismatch(tmp_path: Path):
         checksum=wrong_checksum,
     )
     settings = Settings(download_path=str(tmp_path))
-    file_path = tmp_path / archive["name"]
+    file_path = tmp_path / archive.name
 
     with requests_mock.Mocker() as m:
-        m.get(archive["url"], content=mock_content)
+        m.get(archive.url, content=mock_content)
         with pytest.raises(ValueError, match="Checksum mismatch"):
             download_archive(archive, settings)
 
@@ -151,10 +152,10 @@ def test_download_archive_request_error(tmp_path: Path):
         checksum="dummychecksum",
     )
     settings = Settings(download_path=str(tmp_path))
-    file_path = tmp_path / archive["name"]
+    file_path = tmp_path / archive.name
 
     with requests_mock.Mocker() as m:
-        m.get(archive["url"], status_code=404)
+        m.get(archive.url, status_code=404)
         with pytest.raises(requests.exceptions.HTTPError):
             download_archive(archive, settings)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,19 +66,28 @@ HTML_FIXTURE = """
 import logging
 
 
+class MockLoader:
+    def __init__(self, db_settings: DatabaseSettings | None):
+        # We accept the settings but ignore them for the mock.
+        pass
+
+    def get_processed_archives(self):
+        # Return an empty set to simulate no archives being processed yet
+        return set()
+
+    def start_run(self, mode):
+        return 1
+
+    def end_run(self, run_id, status, records_loaded=0, error_log=None):
+        pass
+
+    def record_processed_archive(self, name, checksum):
+        pass
+
+
 @pytest.fixture
 def mock_db_loader(monkeypatch: pytest.MonkeyPatch):
     """Fixture to mock the PostgresLoader to avoid real DB connections."""
-
-    class MockLoader:
-        def __init__(self, db_settings: DatabaseSettings):
-            # We accept the settings but ignore them for the mock.
-            pass
-
-        def get_processed_archives(self):
-            # Return an empty set to simulate no archives being processed yet
-            return set()
-
     monkeypatch.setattr("py_load_spl.cli.PostgresLoader", MockLoader)
 
 
@@ -127,3 +136,138 @@ def mock_db_loader(monkeypatch: pytest.MonkeyPatch):
 #     expected_file = tmp_path / archive_name
 #     assert expected_file.exists()
 #     assert expected_file.read_bytes() == mock_content
+
+
+def test_delta_load_no_new_archives(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    """
+    Tests that delta-load handles the case where no new archives are found.
+    """
+    # Mock the functions that would perform external actions
+    mock_loader_instance = MockLoader(None)
+    mock_loader_instance.start_run = lambda mode: 1
+    mock_loader_instance.end_run = lambda run_id, status, count: None
+
+    monkeypatch.setattr("py_load_spl.cli.get_db_loader", lambda settings: mock_loader_instance)
+    monkeypatch.setattr("py_load_spl.cli.download_spl_archives", lambda loader: []) # No new archives
+
+    with caplog.at_level(logging.INFO):
+        result = runner.invoke(app, ["delta-load"])
+
+    assert result.exit_code == 0
+    assert "No new archives found" in result.stdout
+
+
+import zipfile
+import psycopg2
+
+SAMPLE_XML_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="urn:hl7-org:v3">
+  <id root="d1b64b62-050a-4895-924c-d2862d2a6a69" />
+  <setId root="a2c3b6f0-a38f-4b48-96eb-3b2b403816a4" />
+  <versionNumber value="1" />
+  <effectiveTime value="20250909" />
+  <subject>
+    <manufacturedProduct>
+      <manufacturedProduct>
+        <name>Test Drug</name>
+        <formCode code="C42916" displayName="TABLET" />
+        <asEntityWithGeneric>
+          <genericMedicine>
+            <name>TESTMED</name>
+          </genericMedicine>
+        </asEntityWithGeneric>
+      </manufacturedProduct>
+      <manufacturer>
+        <name>Test Corp</name>
+      </manufacturer>
+    </manufacturedProduct>
+  </subject>
+</document>
+"""
+
+
+@pytest.mark.integration
+def test_delta_load_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """
+    An end-to-end integration test for the delta-load command.
+    - Mocks the network calls to the FDA website.
+    - Uses a real PostgreSQL database via testcontainers.
+    - Verifies that data is downloaded, unzipped, parsed, and loaded correctly.
+    """
+    # 1. Prepare mock archive and settings
+    archive_name = "dm_spl_daily_update_09092025.zip"
+    download_url = f"https://example.com/{archive_name}"
+
+    # Create a dummy XML file and zip it
+    xml_file = tmp_path / "test_spl.xml"
+    xml_file.write_text(SAMPLE_XML_CONTENT)
+    zip_file = tmp_path / archive_name
+    with zipfile.ZipFile(zip_file, "w") as zf:
+        zf.write(xml_file, arcname="test_spl.xml")
+
+    mock_content = zip_file.read_bytes()
+    mock_checksum = hashlib.md5(mock_content).hexdigest()
+
+    # 2. Set up the test container and settings
+    with PostgresContainer("postgres:16-alpine") as postgres:
+        test_db_settings = DatabaseSettings(
+            host=postgres.get_container_host_ip(),
+            port=postgres.get_exposed_port(5432),
+            user=postgres.username,
+            password=postgres.password,
+            name=postgres.dbname,
+            adapter="postgresql",
+        )
+        # Point download path to our temp dir
+        test_settings = Settings(db=test_db_settings, download_path=str(tmp_path))
+
+        monkeypatch.setattr("py_load_spl.cli.get_settings", lambda: test_settings)
+        monkeypatch.setattr("py_load_spl.acquisition.get_settings", lambda: test_settings)
+
+        # 3. Run the 'init' command first to set up the schema
+        init_result = runner.invoke(app, ["init"])
+        assert init_result.exit_code == 0
+
+        # 4. Mock the network calls
+        with requests_mock.Mocker() as m:
+            m.get(
+                str(test_settings.fda_source_url),
+                text=HTML_FIXTURE.format(checksum=mock_checksum).replace("09022025", "09092025"),
+            )
+            m.get(
+                "https://example.com/dm_spl_daily_update_09092025.zip",
+                content=mock_content,
+                headers={"Content-Length": str(len(mock_content))},
+            )
+
+            # 5. Run the delta-load command
+            delta_result = runner.invoke(app, ["delta-load"])
+
+        # 6. Assertions
+        assert delta_result.exit_code == 0, f"CLI command failed with output:\n{delta_result.stdout}"
+        assert "Delta load process finished successfully" in delta_result.stdout
+
+        # 7. Verify data in the database directly
+        conn = psycopg2.connect(
+            dbname=postgres.dbname,
+            user=postgres.username,
+            password=postgres.password,
+            host=postgres.get_container_host_ip(),
+            port=postgres.get_exposed_port(5432),
+        )
+        with conn.cursor() as cur:
+            # Check that the archive was recorded
+            cur.execute("SELECT archive_name, archive_checksum FROM etl_processed_archives")
+            processed_archive = cur.fetchone()
+            assert processed_archive[0] == archive_name
+            assert processed_archive[1] == mock_checksum
+
+            # Check that the product was loaded
+            cur.execute("SELECT document_id, set_id, product_name, manufacturer_name, dosage_form FROM products")
+            product = cur.fetchone()
+            assert str(product[0]) == "d1b64b62-050a-4895-924c-d2862d2a6a69"
+            assert str(product[1]) == "a2c3b6f0-a38f-4b48-96eb-3b2b403816a4"
+            assert product[2] == "Test Drug"
+            assert product[3] == "Test Corp"
+            assert product[4] == "TABLET"
+        conn.close()


### PR DESCRIPTION
This commit implements the `delta-load` functionality, a core feature outlined in the FRD.

The new `delta-load` command in the CLI orchestrates the end-to-end incremental loading process:
1.  It calls the acquisition module to download new SPL archives from the FDA source, comparing against previously processed files stored in the database.
2.  It unpacks the new archives into a temporary directory.
3.  It leverages the existing transformation and parsing pipeline to process the new XML files into intermediate CSVs.
4.  It uses the database loader to merge the new data into the production tables using the 'delta-load' mode, which correctly handles UPSERTs.
5.  It records the successfully processed archives in the `etl_processed_archives` table.

This commit also includes:
- A refactoring of the `Archive` data structure to a Pydantic model for improved type safety and consistency.
- A new `unzip_archive` utility function.
- A comprehensive test suite for the new functionality, including a unit test for the no-new-files case and a full end-to-end integration test using `testcontainers` and a real PostgreSQL instance.