### PR TITLE
feat: Implement quarantine for failed XML parsing

### DIFF
--- a/src/py_load_spl/cli.py
+++ b/src/py_load_spl/cli.py
@@ -1,16 +1,18 @@
 import concurrent.futures
 import logging
+import shutil
 import tempfile
+from concurrent.futures import as_completed
 from pathlib import Path
 
 import typer
 from rich.console import Console
 
 from . import __name__ as app_name
-from .config import get_settings
+from .config import Settings, get_settings
 from .db.base import DatabaseLoader
 from .db.postgres import PostgresLoader
-from .parsing import parse_spl_file
+from .parsing import SplParsingError, parse_spl_file
 from .transformation import Transformer
 from .util import setup_logging
 
@@ -41,6 +43,44 @@ def get_db_loader(settings) -> DatabaseLoader:
     else:
         console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
         raise typer.Exit(1)
+
+
+def _quarantine_and_parse_in_parallel(
+    xml_files: list[Path], settings: Settings, executor: concurrent.futures.ProcessPoolExecutor
+):
+    """
+    Parses a list of XML files in parallel, quarantining any file that fails.
+
+    Yields successfully parsed data dictionaries.
+    """
+    futures = {executor.submit(parse_spl_file, file): file for file in xml_files}
+    quarantined_count = 0
+
+    for future in as_completed(futures):
+        source_file_path = futures[future]  # Get the path associated with this future
+        try:
+            yield future.result()
+        except Exception as e:  # Catch ANY exception from the parsing process
+            quarantine_dir = Path(settings.quarantine_path)
+            quarantine_dir.mkdir(parents=True, exist_ok=True)
+            target_path = quarantine_dir / source_file_path.name
+
+            # Ensure the source file still exists before trying to move
+            if source_file_path.exists():
+                shutil.move(str(source_file_path), str(target_path))
+                quarantined_count += 1
+                logging.warning(
+                    f"Moved corrupted file {source_file_path.name} to {target_path} due to parsing error: {e}"
+                )
+            else:
+                logging.warning(
+                    f"Could not quarantine {source_file_path.name} as it was already moved or deleted."
+                )
+
+    if quarantined_count > 0:
+        console.print(
+            f"[bold yellow]Quarantined {quarantined_count} file(s).[/bold yellow]"
+        )
 
 
 @app.command()
@@ -90,9 +130,10 @@ def full_load(
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=settings.max_workers
             ) as executor:
-                parsed_data_stream = executor.map(parse_spl_file, xml_files)
+                parsed_data_stream = _quarantine_and_parse_in_parallel(
+                    xml_files, settings, executor
+                )
                 transformer = Transformer(output_dir=output_dir)
-                # The 'stats' variable will be used in the next step of the plan
                 stats = transformer.transform_stream(parsed_data_stream)
 
             console.print("[green]Parsing and Transformation complete.[/green]")
@@ -164,7 +205,9 @@ def delta_load(ctx: typer.Context) -> None:
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=settings.max_workers
             ) as executor:
-                parsed_data_stream = executor.map(parse_spl_file, xml_files)
+                parsed_data_stream = _quarantine_and_parse_in_parallel(
+                    xml_files, settings, executor
+                )
                 transformer = Transformer(output_dir=csv_temp_dir)
                 stats = transformer.transform_stream(parsed_data_stream)
             console.print("[green]Parsing and Transformation complete.[/green]")

--- a/src/py_load_spl/config.py
+++ b/src/py_load_spl/config.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
     # The FRD requires a configurable download source (F001.1)
     fda_source_url: HttpUrl = "https://dailymed.nlm.nih.gov/dailymed/spl-resources-all-drug-labels.cfm"  # type: ignore
     download_path: str = "data/downloads"
+    quarantine_path: str = Field(
+        default="data/quarantine",
+        description="Directory to move corrupted or unparseable XML files.",
+        env="QUARANTINE_PATH",
+    )
     max_workers: int | None = Field(
         default_factory=os.cpu_count,
         description="Number of parallel processes for parsing. Defaults to number of CPUs.",

--- a/src/py_load_spl/parsing.py
+++ b/src/py_load_spl/parsing.py
@@ -7,6 +7,15 @@ from lxml import etree
 
 logger = logging.getLogger(__name__)
 
+
+class SplParsingError(Exception):
+    """Custom exception for errors during SPL file parsing."""
+
+    def __init__(self, message: str, file_path: Path):
+        self.file_path = file_path
+        super().__init__(f"{message} [file: {file_path}]")
+
+
 # Define the XML namespace for HL7 v3, crucial for XPath queries.
 NAMESPACES = {"hl7": "urn:hl7-org:v3"}
 
@@ -130,6 +139,9 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
 
     except (AttributeError, TypeError, ValueError) as e:
         logger.error(f"Error parsing file {file_path}. Some elements may be missing. Error: {e}")
+        raise SplParsingError(
+            f"A critical error occurred during parsing: {e}", file_path=file_path
+        ) from e
 
     # Free up memory
     root.clear()

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -1,0 +1,110 @@
+import pytest
+from typer.testing import CliRunner
+from pathlib import Path
+import logging
+
+from py_load_spl.cli import app
+from py_load_spl.config import Settings
+
+runner = CliRunner()
+
+# A valid XML sample that should process correctly
+SAMPLE_XML_CONTENT_GOOD = """<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="urn:hl7-org:v3">
+  <id root="d1b64b62-050a-4895-924c-d2862d2a6a69" />
+  <setId root="a2c3b6f0-a38f-4b48-96eb-3b2b403816a4" />
+  <versionNumber value="1" />
+  <effectiveTime value="20250909" />
+  <subject>
+    <manufacturedProduct>
+      <manufacturedProduct>
+        <name>Good Drug</name>
+      </manufacturedProduct>
+    </manufacturedProduct>
+  </subject>
+</document>
+"""
+
+# An invalid XML sample that is missing the critical 'id' element, which should trigger a parsing error
+SAMPLE_XML_CONTENT_BAD = """<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="urn:hl7-org:v3">
+  <!-- Missing id -->
+  <setId root="a2c3b6f0-a38f-4b48-96eb-3b2b403816a4" />
+  <versionNumber value="1" />
+  <effectiveTime value="20250909" />
+  <subject>
+    <manufacturedProduct>
+      <manufacturedProduct>
+        <name>Bad Drug</name>
+      </manufacturedProduct>
+    </manufacturedProduct>
+  </subject>
+</document>
+"""
+
+
+class MockLoader:
+    """A mock loader that does nothing but allows the CLI to run."""
+    def __init__(self, db_settings):
+        pass
+    def start_run(self, mode): return 1
+    def end_run(self, *args, **kwargs): pass
+    def pre_load_optimization(self, mode): pass
+    def bulk_load_to_staging(self, intermediate_dir): pass
+    def merge_from_staging(self, mode): pass
+    def post_load_cleanup(self, mode): pass
+
+@pytest.fixture
+def mock_db_and_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Mocks the DB loader and overrides settings for the test."""
+    quarantine_dir = tmp_path / "quarantine"
+    test_settings = Settings(quarantine_path=str(quarantine_dir))
+
+    monkeypatch.setattr("py_load_spl.cli.get_settings", lambda: test_settings)
+    monkeypatch.setattr("py_load_spl.cli.PostgresLoader", MockLoader)
+    return test_settings
+
+def test_full_load_quarantines_bad_xml(
+    tmp_path: Path,
+    mock_db_and_settings: Settings,
+):
+    """
+    Tests that the full-load command correctly identifies a malformed XML file,
+    moves it to the quarantine directory, and successfully processes the good file.
+    """
+    # 1. Setup: Create source directory and files
+    source_dir = tmp_path / "source_xmls"
+    source_dir.mkdir()
+
+    good_file = source_dir / "good.xml"
+    good_file.write_text(SAMPLE_XML_CONTENT_GOOD)
+
+    bad_file = source_dir / "bad.xml"
+    bad_file.write_text(SAMPLE_XML_CONTENT_BAD)
+
+    quarantine_dir = Path(mock_db_and_settings.quarantine_path)
+
+    # 2. Execute: Run the full-load command.
+    # We run with text logs to make stdout assertion easier.
+    result = runner.invoke(
+        app, ["--log-format", "text", "full-load", "--source", str(source_dir)]
+    )
+
+    # 3. Assertions
+    assert result.exit_code == 0, f"CLI command failed with output:\n{result.stdout}"
+
+    # Check that the bad file was moved
+    assert not bad_file.exists()
+    assert (quarantine_dir / "bad.xml").exists()
+
+    # Check that the good file was not moved
+    assert good_file.exists()
+    assert not (quarantine_dir / "good.xml").exists()
+
+    # Check the log messages in the captured stdout
+    assert "Moved corrupted file bad.xml" in result.stdout
+    assert "Quarantined 1 file(s)." in result.stdout
+    assert "Full load process finished successfully" in result.stdout
+
+    # Verify the content of the quarantined file
+    assert (quarantine_dir / "bad.xml").read_text() == SAMPLE_XML_CONTENT_BAD


### PR DESCRIPTION
This commit introduces a new feature to handle XML parsing failures gracefully, as required by FRD requirement F002.4.

When an XML file fails to parse for any reason during the `full-load` or `delta-load` processes, it is now automatically moved to a configured 'quarantine' directory. This prevents a single corrupted file from halting the entire ETL pipeline and allows for later inspection of problematic files.

Changes include:
- `config.py`: Added a `quarantine_path` setting to the main application configuration.
- `parsing.py`: Introduced a custom `SplParsingError` to provide better semantics for parsing failures.
- `cli.py`: Reworked the parallel processing logic to use `executor.submit` and `as_completed`. A new helper function, `_quarantine_and_parse_in_parallel`, now catches any exception from the parsing function, reliably gets the path of the failed file, and moves it to the quarantine directory.
- `tests/test_quarantine.py`: Added a new integration test that verifies that malformed files are correctly quarantined while valid files are processed successfully.