### PR TITLE
Fix packaging parsing and restore delta load logic

### DIFF
--- a/src/py_load_spl/parsing.py
+++ b/src/py_load_spl/parsing.py
@@ -81,9 +81,11 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
                 data["route_of_administration"] = route_code_el.get("displayName") if route_code_el is not None else None
 
                 # Extract Product NDCs
-                for code_el in _xpa(product_element, ".//hl7:asEquivalentEntity/hl7:code[@codeSystem='2.16.840.1.113883.6.69']"):
-                    if ndc_code := code_el.get("code"):
-                        data["product_ndcs"].append({"ndc_code": ndc_code})
+                as_equivalent_entity_el = _xp(product_element, "./hl7:asEquivalentEntity")
+                if as_equivalent_entity_el is not None:
+                    for code_el in _xpa(as_equivalent_entity_el, "./hl7:code[@codeSystem='2.16.840.1.113883.6.69']"):
+                        if ndc_code := code_el.get("code"):
+                            data["product_ndcs"].append({"ndc_code": ndc_code})
 
                 # Extract ingredients (F003.2)
                 for ingredient_el in _xpa(product_element, ".//hl7:ingredient"):
@@ -111,22 +113,23 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
         if body is not None:
             # Packaging (F003.2)
             for section in _xpa(body, ".//hl7:section"):
-                code_el = _xp(section, "hl7:code")
+                code_el = _xp(section, ".//hl7:code")
                 if code_el is not None and code_el.get("code") in ('34069-5', '51945-4'):
-                    for part_el in section.iterdescendants(f"{{{NAMESPACES['hl7']}}}part"):
-                        part_code_el = _xp(part_el, ".//hl7:code")
-                    package_ndc = part_code_el.get("code") if part_code_el is not None else None
-                    if package_ndc:
-                        desc_el = _xp(part_el, ".//hl7:desc") or _xp(part_el, ".//hl7:name")
-                        form_code_el = _xp(part_el, ".//hl7:formCode")
-                        data["packaging"].append({
-                            "package_ndc": package_ndc,
-                            "package_description": desc_el.text if desc_el is not None else None,
-                            "package_type": form_code_el.get("displayName") if form_code_el is not None else None,
-                        })
+                    for part_el in _xpa(section, ".//hl7:part"):
+                        part_code_el = _xp(part_el, "./hl7:code")
+                        if part_code_el is not None:
+                            desc_el = _xp(part_el, "./hl7:name")
+                            if desc_el is None:
+                                desc_el = _xp(part_el, "./hl7:desc")
+                            form_code_el = _xp(part_el, "./hl7:formCode")
+                            data["packaging"].append({
+                                "package_ndc": part_code_el.get("code"),
+                                "package_description": desc_el.text if desc_el is not None else None,
+                                "package_type": form_code_el.get("displayName") if form_code_el is not None else None,
+                            })
 
             # Marketing Status
-            for act in _xpa(body, ".//hl7:subject/hl7:marketingAct"):
+            for act in _xpa(body, ".//hl7:subject//hl7:marketingAct"):
                 status_code_el = _xp(act, "./hl7:statusCode")
                 effective_time_el = _xp(act, "./hl7:effectiveTime")
                 start_date_el = _xp(effective_time_el, "./hl7:low") if effective_time_el is not None else None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -106,6 +106,13 @@ def test_parse_spl_file(sample_spl_file: Path):
     assert len(data["packaging"]) == 1
     package = data["packaging"][0]
     assert package["package_ndc"] == "12345-678-90"
+    assert package["package_description"] == "30 Tablets in 1 Bottle"
+    assert package["package_type"] == "BOTTLE"
+
+    # Assert product NDCs
+    assert len(data["product_ndcs"]) == 1
+    ndc = data["product_ndcs"][0]
+    assert ndc["ndc_code"] == "12345-678"
 
     # Assert marketing status
     assert len(data["marketing_status"]) == 1

--- a/tests/test_postgres_loader.py
+++ b/tests/test_postgres_loader.py
@@ -218,6 +218,11 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
         ingredients = [row[0] for row in cur.fetchall()]
         assert ingredients == ["Updated Ingredient"]
 
+        # Check that the child records for the untouched product are still there
+        cur.execute("SELECT count(*) FROM ingredients WHERE document_id = %s", (str(untouched_doc_id),))
+        assert cur.fetchone()[0] == 1
+
+
         # Check that staging tables are empty
         cur.execute("SELECT count(*) FROM products_staging")
         assert cur.fetchone()[0] == 0


### PR DESCRIPTION
This commit addresses two main gaps identified in the FRD:

1.  **Improves parsing for packaging and marketing status:** The XPath expressions for parsing packaging and marketing status information have been corrected to be more robust and accurate.

2.  **Restores original `delta_load` logic:** Reverted changes to the delta_load logic to fix a regression introduced in previous commits. The original logic for `delta_load` is preserved.

**Known Issues:**

*   The parsing of `product_ndcs` is still not working correctly. The test for this (`tests/test_parsing.py::test_parse_spl_file`) is currently failing. This needs further investigation.
*   The `delta_load` logic in `merge_from_staging` could be made more efficient by performing a more targeted `INSERT` for child table records, though the current implementation is functionally correct for the existing tests.